### PR TITLE
Modifed to run inside of a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM squidfunk/mkdocs-material:9
-RUN pip install mkdocs-charts-plugin \
-                mkdocs-git-committers-plugin-2 \
-                mkdocs-git-revision-date-localized-plugin \
-                mkdocs-include-markdown-plugin mkdocs-material[imaging] \
-                mkdocs-redirects
+
+WORKDIR /docs
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -68,3 +68,17 @@ Make a local copy of the GitHub repository
 3. Once the site has been built, open a browser window and paste `http://127.0.0.1:8000/` into the search bar and press enter.
 
    Congratulations, your local preview is now live!
+
+### Configure MKdocs in Docker
+
+1. Build the container:
+
+        docker build -t lambda-docs-mkdocs .
+
+1. Run the container:
+
+        docker run --rm -it -p 8000:8000 -v ${PWD}:/docs lambda-docs-mkdocs serve
+
+1. Once the container is running, open a browser window and paste `http://127.0.0.1:8000/lambda-docs-mkdocs` into the search bar and press enter.
+
+    Congratulation, your local preview is now live inside of a container!

--- a/README.md
+++ b/README.md
@@ -73,12 +73,16 @@ Make a local copy of the GitHub repository
 
 1. Build the container:
 
+        ```bash
         docker build -t lambda-docs-mkdocs .
+        ```
 
 1. Run the container:
 
+        ```bash
         docker run --rm -it -p 8000:8000 -v ${PWD}:/docs lambda-docs-mkdocs serve
+        ```
 
 1. Once the container is running, open a browser window and paste `http://127.0.0.1:8000/lambda-docs-mkdocs` into the search bar and press enter.
 
-    Congratulation, your local preview is now live inside of a container!
+Congratulation, your local preview is now live inside of a container!

--- a/README.md
+++ b/README.md
@@ -73,15 +73,15 @@ Make a local copy of the GitHub repository
 
 1. Build the container:
 
-        ```bash
-        docker build -t lambda-docs-mkdocs .
-        ```
+   ```bash
+   docker build -t lambda-docs-mkdocs .
+   ```
 
 1. Run the container:
 
-        ```bash
-        docker run --rm -it -p 8000:8000 -v ${PWD}:/docs lambda-docs-mkdocs serve
-        ```
+   ```bash
+   docker run --rm -it -p 8000:8000 -v ${PWD}:/docs lambda-docs-mkdocs serve
+   ```
 
 1. Once the container is running, open a browser window and paste `http://127.0.0.1:8000/lambda-docs-mkdocs` into the search bar and press enter.
 


### PR DESCRIPTION
- Modified Dockerfile to use /docs directory and use requirements.txt
- Modified README.md to include instructions on how to run in a container

## Description
Modifies the Dockerfile so that mkdocs can be run insider of a container locally. README.md was also modified to include instructions on how to run inside of a container.

## Related issues
<!-- What issues in JIRA or GitHub if any, does this PR relate to? -->

N/A

## Checklist
<!-- Mark the items that apply to this pull request with an 'x'. -->

- [x] Documentation follows the style guidelines of the project.
- [ ] Files used in this PR (e.g., images and PDFs) are committed.
- [x] Changes have been tested locally.
- [ ] Reviewers have been assigned (at least 1 tech writer and 1 eng).

## Additional notes
Loving the new documentation. Keep up the good work!!!
