### PR TITLE
Make the homepage banner unclickable, add LinkedIn to the footer

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ hide:
   - navigation
 ---
 
-![Homepage](assets/images/lambda/MKDocs_banner.png)
+![Homepage](assets/images/lambda/MKDocs_banner.png){ .skip-lightbox }
 
 # Welcome to Lambda Docs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,6 +131,8 @@ extra:
   social:
     - icon: fontawesome/brands/x-twitter
       link: https://x.com/LambdaAPI
+    - icon: fontawesome/brands/linkedin-in
+      Link: https://www.linkedin.com/company/lambda-labs
   analytics:
     provider: google
     property: G-43EZT1FM6Q

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,7 +44,6 @@ nav:
       - public-cloud/1-click-clusters/getting-started.md
       - public-cloud/1-click-clusters/serving-llama-3_1-405b.md
       - public-cloud/1-click-clusters/security-posture.md
-
   - Private Cloud:
       - private-cloud/index.md
   - Hardware:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,7 +105,9 @@ markdown_extensions:
       permalink: "#"
 plugins:
   - charts
-  - glightbox
+  - glightbox:
+      skip_classes:
+        - skip-lightbox
   - include-markdown
   - search
   - social

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -131,7 +131,7 @@ extra:
     - icon: fontawesome/brands/x-twitter
       link: https://x.com/LambdaAPI
     - icon: fontawesome/brands/linkedin-in
-      Link: https://www.linkedin.com/company/lambda-labs
+      link: https://www.linkedin.com/company/lambda-labs
   analytics:
     provider: google
     property: G-43EZT1FM6Q


### PR DESCRIPTION
This fixes the needlessly clickable homepage banner and adds a LinkedIn social icon to the footer.