### PR TITLE
Add Private Cloud index content

### DIFF
--- a/docs/private-cloud/index.md
+++ b/docs/private-cloud/index.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Lambda Private Cloud provides bare metal, single-tenant clusters for defined reservation periods. Lambda builds the cluster to your specifications and hosts it in a secure Lambda data center, providing support for the cluster hardware and firewall. You have sole access to your cluster and firewall. Lambda can additionally provide managed services, like [Managed Kubernetes](/managed-kubernetes/index.md).
+Lambda Private Cloud provides bare metal, single-tenant clusters for defined reservation periods. Lambda builds the cluster to your specifications. Lambda hosts the cluster in a SSAE 18 SOC I, Type II-certified, PCI Compliant data center, providing 24x7 support for the cluster hardware. Access to the cluster and firewall are restricted solely to you. Lambda can additionally provide managed services, like [Managed Kubernetes](/managed-kubernetes/index.md).
 
 <div class="grid cards" markdown>
 

--- a/docs/private-cloud/index.md
+++ b/docs/private-cloud/index.md
@@ -1,1 +1,23 @@
 # Introduction
+
+Lambda Private Cloud provides bare metal, single-tenant clusters for predefined time periods. Lambda builds the cluster to your specifications and hosts it in a secure Lambda data center, providing support for the cluster hardware and firewall. You have sole access to your cluster and firewall. Lambda can additionally provide managed services, like [Managed Kubernetes](/managed-kubernetes/index.md) on these Private Cloud clusters.
+
+<div class="grid cards" markdown>
+
+-   **Private Cloud**
+
+    ---
+
+    Clusters of 512-2000 NVIDIA H200 SXM or GB200 Grace Blackwell Superchip GPUs reserved for a minimum of one year up to three years.
+
+    [:octicons-arrow-right-24: Contact Sales:octicons-link-external-16:](https://lambdalabs.com/talk-to-an-engineer)
+
+-   **Hyperscale**
+
+    ---
+
+    Clusters of 2,000-64,000 NVIDIA GPUs, including NVIDIA H100 Tensorcore, H200 SXM, or GB200 Grace Blackwell Superchip, for reservations between three and ten years.
+
+    [:octicons-arrow-right-24: Contact Sales:octicons-link-external-16:](https://lambdalabs.com/talk-to-an-engineer)
+
+</div>

--- a/docs/private-cloud/index.md
+++ b/docs/private-cloud/index.md
@@ -1,6 +1,6 @@
 # Introduction
 
-Lambda Private Cloud provides bare metal, single-tenant clusters for predefined time periods. Lambda builds the cluster to your specifications and hosts it in a secure Lambda data center, providing support for the cluster hardware and firewall. You have sole access to your cluster and firewall. Lambda can additionally provide managed services, like [Managed Kubernetes](/managed-kubernetes/index.md) on these Private Cloud clusters.
+Lambda Private Cloud provides bare metal, single-tenant clusters for defined reservation periods. Lambda builds the cluster to your specifications and hosts it in a secure Lambda data center, providing support for the cluster hardware and firewall. You have sole access to your cluster and firewall. Lambda can additionally provide managed services, like [Managed Kubernetes](/managed-kubernetes/index.md).
 
 <div class="grid cards" markdown>
 


### PR DESCRIPTION
## Description
This PR adds basic introductory content about Lambda Private Cloud offerings, reflecting the new messaging in [Selling an AI Cloud](https://docs.google.com/document/d/1FbuRKZ2AJCQkZoMaNmLRi9xmgCwE27wVlr3uRtXTvwU/edit#heading=h.1wu28hjhvcz5). 

